### PR TITLE
修复B站ugc、番剧、影视空格无法控制播放暂停的bug

### DIFF
--- a/dist/h5player.js
+++ b/dist/h5player.js
@@ -950,8 +950,8 @@ const taskConf = {
         return true
       }
     },
-    autoPlay: '.bilibili-player-video-btn-start',
-    switchPlayStatus: '.bilibili-player-video-btn-start',
+    // autoPlay: '.bilibili-player-video-btn-start',
+    // switchPlayStatus: '.bilibili-player-video-btn-start',
     next: '.bilibili-player-video-btn-next',
     init: function (h5Player, taskConf) {},
     shortcuts: {

--- a/src/h5player.js
+++ b/src/h5player.js
@@ -197,8 +197,8 @@ class FullScreen {
     'bilibili.com': {
       fullScreen: '[data-text="进入全屏"]',
       webFullScreen: '[data-text="网页全屏"]',
-      autoPlay: '.bilibili-player-video-btn-start',
-      switchPlayStatus: '.bilibili-player-video-btn-start'
+      // autoPlay: '.bilibili-player-video-btn-start',
+      // switchPlayStatus: '.bilibili-player-video-btn-start'
     },
     'live.bilibili.com': {
       fullScreen: '.bilibili-live-player-video-controller-fullscreen-btn button',

--- a/src/h5player/h5PlayerTccInit.js
+++ b/src/h5player/h5PlayerTccInit.js
@@ -94,8 +94,8 @@ const taskConf = {
         return true
       }
     },
-    autoPlay: '.bilibili-player-video-btn-start',
-    switchPlayStatus: '.bilibili-player-video-btn-start',
+    // autoPlay: '.bilibili-player-video-btn-start',
+    // switchPlayStatus: '.bilibili-player-video-btn-start',
     next: '.bilibili-player-video-btn-next',
     init: function (h5Player, taskConf) {},
     shortcuts: {


### PR DESCRIPTION
B站更新播放器后空格键无法控制播放/暂停
because of bilibili updated the player, the space doesn't working right now
修复空格无效的bug
fix space not working when play/pause in bilibili

already tested in chrome and firefox