### PR TITLE
feat: Pass general data to custom hotkey configs

### DIFF
--- a/src/libs/utils/hotkeysRunner.js
+++ b/src/libs/utils/hotkeysRunner.js
@@ -278,10 +278,16 @@ class HotkeysRunner {
       }
 
       /* 执行hotkeyConf.command对应的函数或命令 */
-      const args = toArrArgs(hotkeyConf.args)
-      let commandFunc = hotkeyConf.command
+      let args = [];
+      let commandFunc = () => {};
       if (target && typeof hotkeyConf.command === 'string') {
-        commandFunc = getValByPath(target, hotkeyConf.command)
+        /* Reference via internal function name - Pass configured arguments */
+        commandFunc = getValByPath$1(target, hotkeyConf.command);
+        args = toArrArgs(hotkeyConf.args);
+      } else {
+        /* Function object - Pass general info */
+        commandFunc = hotkeyConf.command;
+        args = toArrArgs([h5Player, taskConf, event]);
       }
 
       if (!(commandFunc instanceof Function) && target) {


### PR DESCRIPTION
Hi, I love the possibility of custom configurations, but only site-specific ones seem to get detailed info on what's happening.
So this change is just that. It's a bit different from the site-specific one because this one is missing the player, but as the h5Player has an equivalent property it should not be necessary

I did not update the dist as I was not sure if I was supposed to be (I was also not sure how to do it properly)
To be fair this is more of a feature request than a pull request, I just implemented it so that I can use it immediately, and I thought I'd create a pull request from it in case it's of any help

Google Translated Chinese:
嗨，我喜欢自定义配置的可能性，但似乎只有特定于站点的配置才能获得有关正在发生的事情的详细信息。
所以这个变化就是这样。它与特定于站点的有点不同，因为这个缺少播放器，但由于 h5Player 具有等效属性，因此没有必要

我没有更新 dist，因为我不确定我是否应该更新（我也不确定如何正确地做）
公平地说，这更像是一个功能请求而不是拉取请求，我只是实现了它以便我可以立即使用它，我想我会从中创建一个拉取请求以防它有任何帮助