### PR TITLE
Fix: 动画疯样式注入异常

### DIFF
--- a/dist/h5player.user.js
+++ b/dist/h5player.user.js
@@ -13894,9 +13894,19 @@ const h5Player = {
         parentNode.setAttribute('style-backup', backupSty);
         backupStyle = defStyle;
       } else {
-        /* 如果defStyle被外部修改了，则需要更新备份样式 */
+        /* 如果defStyle被外部修改了，则需要更新备份样式（剔除tips逻辑自身写入的样式，避免备份被污染） */
         if (defStyle && !defStyle.includes('style-backup')) {
-          backupStyle = defStyle;
+          const defStyleObj = inlineStyleToObj(defStyle);
+          /* 仅当position为tips逻辑写入时才剔除 */
+          if (['static', 'inherit', 'initial', 'unset', ''].includes(parentNode.getAttribute('def-position') || '')) {
+            delete defStyleObj.position;
+          }
+          delete defStyleObj['min-width'];
+          delete defStyleObj['min-height'];
+          backupStyle = objToInlineStyle(defStyleObj);
+        } else if (!defStyle) {
+          /* 容器样式已还原为空时，备份也置空，避免还原时残留占位样式 */
+          backupStyle = '';
         }
       }
 
@@ -13965,9 +13975,8 @@ const h5Player = {
         // 隐藏提示框和还原样式
         style.opacity = 0;
         style.display = 'none';
-        if (backupStyle) {
-          parentNode.setAttribute('style', backupStyle);
-        }
+        /* 备份样式为空时也需要还原，否则min-width/min-height等样式会残留在容器上 */
+        parentNode.setAttribute('style', backupStyle);
       }, 2000);
     }
 

--- a/src/h5player/h5player.js
+++ b/src/h5player/h5player.js
@@ -1615,9 +1615,19 @@ const h5Player = {
         parentNode.setAttribute('style-backup', backupSty)
         backupStyle = defStyle
       } else {
-        /* 如果defStyle被外部修改了，则需要更新备份样式 */
+        /* 如果defStyle被外部修改了，则需要更新备份样式（剔除tips逻辑自身写入的样式，避免备份被污染） */
         if (defStyle && !defStyle.includes('style-backup')) {
-          backupStyle = defStyle
+          const defStyleObj = inlineStyleToObj(defStyle)
+          /* 仅当position为tips逻辑写入时才剔除 */
+          if (['static', 'inherit', 'initial', 'unset', ''].includes(parentNode.getAttribute('def-position') || '')) {
+            delete defStyleObj.position
+          }
+          delete defStyleObj['min-width']
+          delete defStyleObj['min-height']
+          backupStyle = objToInlineStyle(defStyleObj)
+        } else if (!defStyle) {
+          /* 容器样式已还原为空时，备份也置空，避免还原时残留占位样式 */
+          backupStyle = ''
         }
       }
 
@@ -1686,9 +1696,8 @@ const h5Player = {
         // 隐藏提示框和还原样式
         style.opacity = 0
         style.display = 'none'
-        if (backupStyle) {
-          parentNode.setAttribute('style', backupStyle)
-        }
+        /* 备份样式为空时也需要还原，否则min-width/min-height等样式会残留在容器上 */
+        parentNode.setAttribute('style', backupStyle)
       }, 2000)
     }
 


### PR DESCRIPTION
## 问题

网站：https://ani.gamer.com.tw

脚本入的 tips 的 Style 得不到清理，导致画面的宽高出现异常，这个问题应该已经存在很多年了。

<img width="2842" height="1916" alt="image" src="https://github.com/user-attachments/assets/65ea89c4-a678-4f96-a288-dec7f71ae786" />

<img width="2940" height="1860" alt="image" src="https://github.com/user-attachments/assets/a90cc8ac-8e9b-4760-9ffe-7da500b0cdeb" />


## 测试注入效果脚本

```js
(() => {
  const v = document.querySelector('video')
  if (!v) return '未找到视频'

  /* 复刻 getTipsContainer()：从 video 的父级开始，0×0 就往上找一级 */
  let container = v.parentNode
  const box = container.getBoundingClientRect()
  if ((!box.width || !box.height) && container.parentNode) {
    container = container.parentNode
  }

  const containerBox = container.getBoundingClientRect()
  const playerBox = v.getBoundingClientRect()
  const defStyle = container.getAttribute('style') || ''

  return {
    容器: container.tagName + (container.id ? '#' + container.id : ''),
    容器当前style_即defStyle将读到的值: defStyle,
    容器尺寸: [Math.round(containerBox.width), Math.round(containerBox.height)],
    视频尺寸: [Math.round(playerBox.width), Math.round(playerBox.height)],
    tips此刻触发是否会写入minHeight: !containerBox.width || !containerBox.height
  }
})()
```
## 修复前
交互几次，得到的响应为：

```
{
    "容器": "DIV#video-container",
    "容器当前style_即defStyle将读到的值": ";position: relative;min-width:793px;min-height:446.0625px;position: relative;position: relative;position: relative;position: relative;position: relative;position: relative;position: relative;position: relative;position: relative;position: relative;position: relative;position: relative;position: relative",
    "容器尺寸": [
        793,
        446
    ],
    "视频尺寸": [
        446,
        793
    ],
    "tips此刻触发是否会写入minHeight": false
}
```

## 修复后
```
{
  "容器": "DIV#video-container",
  "容器当前style_即defStyle将读到的值": "",
  "容器尺寸": [
    1383,
    0
  ],
  "视频尺寸": [
    1383,
    777
  ],
  "tips此刻触发是否会写入minHeight": true
}
```