### PR TITLE
fix(menu): prevent duplicate configuration editor tabs

### DIFF
--- a/dist/h5player.user.js
+++ b/dist/h5player.user.js
@@ -1301,9 +1301,7 @@ function getPageWindowSync (rawFunction) {
 }
 
 function openInTab (url, opts, referer) {
-  // fix tampermonkey menu bug start
-  // 由于tampermonkey的菜单功注册和取消注册存在某些难以排查的bug，所以这处对openInTab的打开频率进行了限制，以解决点击tampermonkey 菜单打开链接时候重复打开一堆相同URL的问题
-  // 此方法治标不治本，还是会遗留很多菜单注册和取消注册留下的坑，建议替换chrome插件实现当前脚本功能
+  // 防御性限制同一URL的打开频率，避免快速重复点击或第三方脚本重复触发
 
   // 使用GM_getValue/GM_setValue或sessionStorage控制同一URL的调用频率
   const now = Date.now();
@@ -1331,8 +1329,6 @@ function openInTab (url, opts, referer) {
 
     sessionStorage.setItem(sessionKey, now.toString());
   }
-  // fix tampermonkey menu bug end
-
   if (referer) {
     const urlObj = parseURL(url);
     if (!urlObj.params.referer) {
@@ -5273,84 +5269,101 @@ function hackDefineProperty () {
  */
 
 const monkeyMenu = {
-  menuIds: {},
-  on (title, fn, accessKey) {
-    if (title instanceof Function) {
-      title = title();
+  menuIds: new Map(),
+  on (menu, menuKey) {
+    const title = menu.title instanceof Function ? menu.title() : menu.title;
+    const registeredMenu = this.menuIds.get(menuKey);
+
+    /* 标题和快捷键没有变化时复用原命令，只更新实际执行的菜单配置 */
+    if (registeredMenu && registeredMenu.title === title && registeredMenu.accessKey === menu.accessKey) {
+      registeredMenu.menu = menu;
+      return registeredMenu.id
+    }
+
+    if (registeredMenu) {
+      const hasUnregistered = this.off(menuKey);
+      if (!hasUnregistered) {
+        /* 注销失败时继续复用旧命令，避免再次注册造成回调叠加 */
+        registeredMenu.menu = menu;
+        return registeredMenu.id
+      }
     }
 
     if (window.GM_registerMenuCommand) {
-      const menuId = window.GM_registerMenuCommand(title, fn, accessKey);
-
-      this.menuIds[menuId] = {
+      const menuInfo = {
+        id: null,
         title,
-        fn,
-        accessKey
+        accessKey: menu.accessKey,
+        menu
       };
+      const menuFn = (...args) => {
+        try {
+          menuInfo.menu.fn.apply(menuInfo.menu, args);
+        } catch (e) {
+          console.error('[monkeyMenu]', menuInfo.title, e);
+        }
+      };
+      const menuId = window.GM_registerMenuCommand(title, menuFn, menu.accessKey);
+
+      menuInfo.id = menuId;
+      this.menuIds.set(menuKey, menuInfo);
 
       return menuId
     }
   },
 
-  off (id) {
-    if (window.GM_unregisterMenuCommand) {
-      delete this.menuIds[id];
+  off (menuKey) {
+    const menuInfo = this.menuIds.get(menuKey);
+    if (!menuInfo) return true
 
-      /**
-       * 批量移除已注册的按钮时，在某些性能较差的机子上会留下数字title的菜单残留
-       * 应该属于插件自身导致的BUG，暂时无法解决
-       * 所以此处暂时不进行菜单移除，tampermonkey会自动对同名菜单进行合并
-       */
-      // return window.GM_unregisterMenuCommand(id)
+    /* 无法确认命令ID或缺少注销API时保留旧命令，防止重复注册 */
+    if (menuInfo.id === null || menuInfo.id === undefined || !window.GM_unregisterMenuCommand) {
+      return false
     }
+
+    try {
+      window.GM_unregisterMenuCommand(menuInfo.id);
+    } catch (e) {
+      console.error('[monkeyMenu][unregister]', menuInfo.title, e);
+      return false
+    }
+
+    this.menuIds.delete(menuKey);
+    return true
   },
 
   clear () {
-    Object.keys(this.menuIds).forEach(id => {
-      this.off(id);
+    Array.from(this.menuIds.keys()).forEach(menuKey => {
+      this.off(menuKey);
     });
   },
 
   /**
-   * 通过菜单配置进行批量注册，注册前会清空之前注册过的所有菜单
-   * @param {array|function} menuOpts 菜单配置，如果是函数则会调用该函数获取菜单配置，并且当菜单被点击后会重新创建菜单，实现菜单的动态更新
+   * 通过菜单配置同步注册结果，仅新增、移除或更新发生变化的命令
+   * @param {array|function} menuOpts 菜单配置，如果是函数则会调用该函数获取菜单配置
    */
   build (menuOpts) {
-    this.clear();
-
-    if (Array.isArray(menuOpts)) {
-      menuOpts.forEach(menu => {
-        if (menu.disable === true) { return }
-        this.on(menu.title, menu.fn, menu.accessKey);
-      });
-    } else if (menuOpts instanceof Function) {
-      const menuList = menuOpts();
-      if (Array.isArray(menuList)) {
-        this._menuBuilder_ = menuOpts;
-
-        menuList.forEach(menu => {
-          if (menu.disable === true) { return }
-
-          const menuFn = () => {
-            try {
-              menu.fn.apply(menu, arguments);
-            } catch (e) {
-              console.error('[monkeyMenu]', menu.title, e);
-            }
-
-            // 每次菜单点击后，重新注册菜单，这样可以确保菜单的状态是最新的
-            setTimeout(() => {
-              // console.log('[monkeyMenu rebuild]', menu.title)
-              this.build(this._menuBuilder_);
-            }, 100);
-          };
-
-          this.on(menu.title, menuFn, menu.accessKey);
-        });
-      } else {
-        console.error('monkeyMenu build error, no menuList return', menuOpts);
-      }
+    const menuList = menuOpts instanceof Function ? menuOpts() : menuOpts;
+    if (!Array.isArray(menuList)) {
+      console.error('monkeyMenu build error, no menuList return', menuOpts);
+      return
     }
+
+    const activeMenuKeys = new Set();
+    menuList.forEach(menu => {
+      if (menu.disable === true || !(menu.fn instanceof Function)) return
+
+      /* 显式key可处理重复创建的函数，默认使用稳定的fn引用作为菜单标识 */
+      const menuKey = menu.key || menu.fn;
+      activeMenuKeys.add(menuKey);
+      this.on(menu, menuKey);
+    });
+
+    Array.from(this.menuIds.keys()).forEach(menuKey => {
+      if (!activeMenuKeys.has(menuKey)) {
+        this.off(menuKey);
+      }
+    });
   }
 };
 
@@ -5810,44 +5823,71 @@ const globalFunctional = {
  * @github       https://github.com/xxxily
  */
 
+function addTitlePrefix (menus, titlePrefix) {
+  menus.forEach(menu => {
+    const title = menu.title;
+    menu.title = () => titlePrefix + (title instanceof Function ? title() : title);
+  });
+}
+
 let monkeyMenuList = [
-  { ...globalFunctional.openWebsite },
+  { key: 'openWebsite', type: 'global', ...globalFunctional.openWebsite },
   // { ...globalFunctional.openHotkeysPage },
   {
+    key: 'openIssuesPage',
+    type: 'global',
     ...globalFunctional.openIssuesPage,
     disable: !configManager.get('enhance.unfoldMenu')
   },
-  { ...globalFunctional.openDonatePage },
-  { ...globalFunctional.openAiProjectsPage },
+  { key: 'openDonatePage', type: 'global', ...globalFunctional.openDonatePage },
+  { key: 'openAiProjectsPage', type: 'global', ...globalFunctional.openAiProjectsPage },
   {
+    key: 'toggleScriptEnableState',
+    type: 'local',
     ...globalFunctional.toggleScriptEnableState
   },
   {
+    key: 'toggleGUIStatusUnderCurrentSite',
+    type: 'local',
     ...globalFunctional.toggleGUIStatusUnderCurrentSite,
     disable: configManager.getLocalStorage('ui.enable') !== false
   },
   {
+    key: 'toggleGUIStatus',
+    type: 'global',
     ...globalFunctional.toggleGUIStatus,
     disable: configManager.getGlobalStorage('ui.enable') === false ? false : !configManager.get('enhance.unfoldMenu')
   },
   {
+    key: 'toggleHotkeysStatusUnderCurrentSite',
+    type: 'local',
     ...globalFunctional.toggleHotkeysStatusUnderCurrentSite,
     disable: configManager.getLocalStorage('enableHotkeys') !== false
   },
   {
+    key: 'toggleHotkeysStatus',
+    type: 'global',
     ...globalFunctional.toggleHotkeysStatus,
     disable: configManager.get('enableHotkeys') !== false
   },
-  { ...globalFunctional.openCustomConfigurationEditor },
+  { key: 'openCustomConfigurationEditor', type: 'global', ...globalFunctional.openCustomConfigurationEditor },
   /* 展开或收起菜单 */
-  { ...globalFunctional.toggleExpandedOrCollapsedStateOfMonkeyMenu },
+  { key: 'toggleExpandedOrCollapsedStateOfMonkeyMenu', type: 'global', ...globalFunctional.toggleExpandedOrCollapsedStateOfMonkeyMenu },
   {
+    key: 'restoreGlobalConfiguration',
+    type: 'global',
     ...globalFunctional.restoreGlobalConfiguration,
     disable: !configManager.get('enhance.unfoldMenu')
   }
 ];
 
-/* 菜单构造函数（必须是函数才能在点击后动态更新菜单状态） */
+if (isInIframe()) {
+  /* iframe只保留作用于自身的基础菜单，全局菜单统一交由顶层页面注册 */
+  monkeyMenuList = monkeyMenuList.filter(menu => menu.type === 'local');
+  addTitlePrefix(monkeyMenuList, `[${location.hostname}]`);
+}
+
+/* 菜单构造函数，用于按最新列表同步菜单状态 */
 function menuBuilder () {
   return monkeyMenuList
 }
@@ -5865,11 +5905,23 @@ function addMenu (menuOpts, before) {
   menuOpts = Array.isArray(menuOpts) ? menuOpts : [menuOpts];
   menuOpts = menuOpts.filter(item => item.title && !item.disabled);
 
+  const newMenus = [];
+  menuOpts.forEach(menu => {
+    const menuKey = menu.key || menu.fn;
+    const registeredIndex = monkeyMenuList.findIndex(item => (item.key || item.fn) === menuKey);
+
+    if (registeredIndex > -1) {
+      monkeyMenuList[registeredIndex] = menu;
+    } else {
+      newMenus.push(menu);
+    }
+  });
+
   if (before) {
     /* 将菜单追加到其它菜单的前面 */
-    monkeyMenuList = menuOpts.concat(monkeyMenuList);
+    monkeyMenuList = newMenus.concat(monkeyMenuList);
   } else {
-    monkeyMenuList = monkeyMenuList.concat(menuOpts);
+    monkeyMenuList = monkeyMenuList.concat(newMenus);
   }
 
   /* 重新注册菜单 */
@@ -5885,63 +5937,67 @@ function registerH5playerMenus (h5player) {
   const foldMenu = !configManager.get('enhance.unfoldMenu');
 
   if (player && !t._hasRegisterH5playerMenus_) {
-    const menus = [
+    let menus = [
       {
+        key: 'openCrossOriginFramePage',
         ...globalFunctional.openCrossOriginFramePage,
+        type: 'local',
         disable: foldMenu || !isInCrossOriginFrame()
       },
       {
+        key: 'toggleSetCurrentTimeFunctional',
         ...globalFunctional.toggleSetCurrentTimeFunctional,
         type: 'local',
         disable: foldMenu
       },
       {
+        key: 'toggleSetVolumeFunctional',
         ...globalFunctional.toggleSetVolumeFunctional,
         type: 'local',
         disable: foldMenu
       },
       {
+        key: 'toggleSetPlaybackRateFunctional',
         ...globalFunctional.toggleSetPlaybackRateFunctional,
         type: 'global',
         disable: foldMenu
       },
       {
+        key: 'toggleAcousticGainFunctional',
         ...globalFunctional.toggleAcousticGainFunctional,
         type: 'global',
         disable: foldMenu
       },
       {
+        key: 'toggleCrossOriginControlFunctional',
         ...globalFunctional.toggleCrossOriginControlFunctional,
         type: 'global',
         disable: foldMenu
       },
       {
+        key: 'toggleExperimentFeatures',
         ...globalFunctional.toggleExperimentFeatures,
         type: 'global',
         disable: foldMenu
       },
       {
+        key: 'toggleExternalCustomConfiguration',
         ...globalFunctional.toggleExternalCustomConfiguration,
         type: 'global',
         disable: foldMenu
       },
       {
+        key: 'toggleDebugMode',
         ...globalFunctional.toggleDebugMode,
+        type: 'global',
         disable: foldMenu
       }
     ];
 
-    let titlePrefix = '';
     if (isInIframe()) {
-      titlePrefix = `[${location.hostname}]`;
-
-      /* 补充title前缀 */
-      menus.forEach(menu => {
-        const titleFn = menu.title;
-        if (titleFn instanceof Function && menu.type === 'local') {
-          menu.title = () => titlePrefix + titleFn();
-        }
-      });
+      /* iframe只注册作用于自身的菜单，全局菜单统一交由顶层页面注册 */
+      menus = menus.filter(menu => menu.type === 'local');
+      addTitlePrefix(menus, `[${location.hostname}]`);
     }
 
     addMenu(menus);
@@ -12802,6 +12858,7 @@ const h5Player = {
       }
 
       addMenu({
+        key: 'toggleInitAutoPlay',
         title: () => configManager.getLocalStorage('media.autoPlay') ? i18n.t('disableInitAutoPlay') : i18n.t('enableInitAutoPlay'),
         fn: () => {
           const confirm = window.confirm(configManager.getLocalStorage('media.autoPlay') ? i18n.t('disableInitAutoPlay') : i18n.t('enableInitAutoPlay'));
@@ -12811,6 +12868,7 @@ const h5Player = {
               alert(i18n.t('configFail'));
             } else {
               configManager.setLocalStorage('media.autoPlay', !autoPlay);
+              setTimeout(() => menuRegister(), 100);
             }
           }
         }

--- a/src/h5player/h5player.js
+++ b/src/h5player/h5player.js
@@ -511,6 +511,7 @@ const h5Player = {
       }
 
       addMenu({
+        key: 'toggleInitAutoPlay',
         title: () => configManager.getLocalStorage('media.autoPlay') ? i18n.t('disableInitAutoPlay') : i18n.t('enableInitAutoPlay'),
         fn: () => {
           const confirm = window.confirm(configManager.getLocalStorage('media.autoPlay') ? i18n.t('disableInitAutoPlay') : i18n.t('enableInitAutoPlay'))
@@ -520,6 +521,7 @@ const h5Player = {
               alert(i18n.t('configFail'))
             } else {
               configManager.setLocalStorage('media.autoPlay', !autoPlay)
+              setTimeout(() => menuRegister(), 100)
             }
           }
         }

--- a/src/h5player/helper.js
+++ b/src/h5player/helper.js
@@ -133,9 +133,7 @@ function getPageWindowSync (rawFunction) {
 }
 
 function openInTab (url, opts, referer) {
-  // fix tampermonkey menu bug start
-  // 由于tampermonkey的菜单功注册和取消注册存在某些难以排查的bug，所以这处对openInTab的打开频率进行了限制，以解决点击tampermonkey 菜单打开链接时候重复打开一堆相同URL的问题
-  // 此方法治标不治本，还是会遗留很多菜单注册和取消注册留下的坑，建议替换chrome插件实现当前脚本功能
+  // 防御性限制同一URL的打开频率，避免快速重复点击或第三方脚本重复触发
 
   // 使用GM_getValue/GM_setValue或sessionStorage控制同一URL的调用频率
   const now = Date.now()
@@ -163,8 +161,6 @@ function openInTab (url, opts, referer) {
 
     sessionStorage.setItem(sessionKey, now.toString())
   }
-  // fix tampermonkey menu bug end
-
   if (referer) {
     const urlObj = parseURL(url)
     if (!urlObj.params.referer) {

--- a/src/h5player/menuManager.js
+++ b/src/h5player/menuManager.js
@@ -14,44 +14,71 @@ import {
 } from '../libs/utils/index'
 import globalFunctional from './globalFunctional'
 
+function addTitlePrefix (menus, titlePrefix) {
+  menus.forEach(menu => {
+    const title = menu.title
+    menu.title = () => titlePrefix + (title instanceof Function ? title() : title)
+  })
+}
+
 let monkeyMenuList = [
-  { ...globalFunctional.openWebsite },
+  { key: 'openWebsite', type: 'global', ...globalFunctional.openWebsite },
   // { ...globalFunctional.openHotkeysPage },
   {
+    key: 'openIssuesPage',
+    type: 'global',
     ...globalFunctional.openIssuesPage,
     disable: !configManager.get('enhance.unfoldMenu')
   },
-  { ...globalFunctional.openDonatePage },
-  { ...globalFunctional.openAiProjectsPage },
+  { key: 'openDonatePage', type: 'global', ...globalFunctional.openDonatePage },
+  { key: 'openAiProjectsPage', type: 'global', ...globalFunctional.openAiProjectsPage },
   {
+    key: 'toggleScriptEnableState',
+    type: 'local',
     ...globalFunctional.toggleScriptEnableState
   },
   {
+    key: 'toggleGUIStatusUnderCurrentSite',
+    type: 'local',
     ...globalFunctional.toggleGUIStatusUnderCurrentSite,
     disable: configManager.getLocalStorage('ui.enable') !== false
   },
   {
+    key: 'toggleGUIStatus',
+    type: 'global',
     ...globalFunctional.toggleGUIStatus,
     disable: configManager.getGlobalStorage('ui.enable') === false ? false : !configManager.get('enhance.unfoldMenu')
   },
   {
+    key: 'toggleHotkeysStatusUnderCurrentSite',
+    type: 'local',
     ...globalFunctional.toggleHotkeysStatusUnderCurrentSite,
     disable: configManager.getLocalStorage('enableHotkeys') !== false
   },
   {
+    key: 'toggleHotkeysStatus',
+    type: 'global',
     ...globalFunctional.toggleHotkeysStatus,
     disable: configManager.get('enableHotkeys') !== false
   },
-  { ...globalFunctional.openCustomConfigurationEditor },
+  { key: 'openCustomConfigurationEditor', type: 'global', ...globalFunctional.openCustomConfigurationEditor },
   /* 展开或收起菜单 */
-  { ...globalFunctional.toggleExpandedOrCollapsedStateOfMonkeyMenu },
+  { key: 'toggleExpandedOrCollapsedStateOfMonkeyMenu', type: 'global', ...globalFunctional.toggleExpandedOrCollapsedStateOfMonkeyMenu },
   {
+    key: 'restoreGlobalConfiguration',
+    type: 'global',
     ...globalFunctional.restoreGlobalConfiguration,
     disable: !configManager.get('enhance.unfoldMenu')
   }
 ]
 
-/* 菜单构造函数（必须是函数才能在点击后动态更新菜单状态） */
+if (isInIframe()) {
+  /* iframe只保留作用于自身的基础菜单，全局菜单统一交由顶层页面注册 */
+  monkeyMenuList = monkeyMenuList.filter(menu => menu.type === 'local')
+  addTitlePrefix(monkeyMenuList, `[${location.hostname}]`)
+}
+
+/* 菜单构造函数，用于按最新列表同步菜单状态 */
 function menuBuilder () {
   return monkeyMenuList
 }
@@ -69,11 +96,23 @@ export function addMenu (menuOpts, before) {
   menuOpts = Array.isArray(menuOpts) ? menuOpts : [menuOpts]
   menuOpts = menuOpts.filter(item => item.title && !item.disabled)
 
+  const newMenus = []
+  menuOpts.forEach(menu => {
+    const menuKey = menu.key || menu.fn
+    const registeredIndex = monkeyMenuList.findIndex(item => (item.key || item.fn) === menuKey)
+
+    if (registeredIndex > -1) {
+      monkeyMenuList[registeredIndex] = menu
+    } else {
+      newMenus.push(menu)
+    }
+  })
+
   if (before) {
     /* 将菜单追加到其它菜单的前面 */
-    monkeyMenuList = menuOpts.concat(monkeyMenuList)
+    monkeyMenuList = newMenus.concat(monkeyMenuList)
   } else {
-    monkeyMenuList = monkeyMenuList.concat(menuOpts)
+    monkeyMenuList = monkeyMenuList.concat(newMenus)
   }
 
   /* 重新注册菜单 */
@@ -89,63 +128,67 @@ export function registerH5playerMenus (h5player) {
   const foldMenu = !configManager.get('enhance.unfoldMenu')
 
   if (player && !t._hasRegisterH5playerMenus_) {
-    const menus = [
+    let menus = [
       {
+        key: 'openCrossOriginFramePage',
         ...globalFunctional.openCrossOriginFramePage,
+        type: 'local',
         disable: foldMenu || !isInCrossOriginFrame()
       },
       {
+        key: 'toggleSetCurrentTimeFunctional',
         ...globalFunctional.toggleSetCurrentTimeFunctional,
         type: 'local',
         disable: foldMenu
       },
       {
+        key: 'toggleSetVolumeFunctional',
         ...globalFunctional.toggleSetVolumeFunctional,
         type: 'local',
         disable: foldMenu
       },
       {
+        key: 'toggleSetPlaybackRateFunctional',
         ...globalFunctional.toggleSetPlaybackRateFunctional,
         type: 'global',
         disable: foldMenu
       },
       {
+        key: 'toggleAcousticGainFunctional',
         ...globalFunctional.toggleAcousticGainFunctional,
         type: 'global',
         disable: foldMenu
       },
       {
+        key: 'toggleCrossOriginControlFunctional',
         ...globalFunctional.toggleCrossOriginControlFunctional,
         type: 'global',
         disable: foldMenu
       },
       {
+        key: 'toggleExperimentFeatures',
         ...globalFunctional.toggleExperimentFeatures,
         type: 'global',
         disable: foldMenu
       },
       {
+        key: 'toggleExternalCustomConfiguration',
         ...globalFunctional.toggleExternalCustomConfiguration,
         type: 'global',
         disable: foldMenu
       },
       {
+        key: 'toggleDebugMode',
         ...globalFunctional.toggleDebugMode,
+        type: 'global',
         disable: foldMenu
       }
     ]
 
-    let titlePrefix = ''
     if (isInIframe()) {
-      titlePrefix = `[${location.hostname}]`
-
-      /* 补充title前缀 */
-      menus.forEach(menu => {
-        const titleFn = menu.title
-        if (titleFn instanceof Function && menu.type === 'local') {
-          menu.title = () => titlePrefix + titleFn()
-        }
-      })
+      /* iframe只注册作用于自身的菜单，全局菜单统一交由顶层页面注册 */
+      menus = menus.filter(menu => menu.type === 'local')
+      addTitlePrefix(menus, `[${location.hostname}]`)
     }
 
     addMenu(menus)

--- a/src/h5player/monkeyMenu.js
+++ b/src/h5player/monkeyMenu.js
@@ -6,84 +6,101 @@
  */
 
 const monkeyMenu = {
-  menuIds: {},
-  on (title, fn, accessKey) {
-    if (title instanceof Function) {
-      title = title()
+  menuIds: new Map(),
+  on (menu, menuKey) {
+    const title = menu.title instanceof Function ? menu.title() : menu.title
+    const registeredMenu = this.menuIds.get(menuKey)
+
+    /* 标题和快捷键没有变化时复用原命令，只更新实际执行的菜单配置 */
+    if (registeredMenu && registeredMenu.title === title && registeredMenu.accessKey === menu.accessKey) {
+      registeredMenu.menu = menu
+      return registeredMenu.id
+    }
+
+    if (registeredMenu) {
+      const hasUnregistered = this.off(menuKey)
+      if (!hasUnregistered) {
+        /* 注销失败时继续复用旧命令，避免再次注册造成回调叠加 */
+        registeredMenu.menu = menu
+        return registeredMenu.id
+      }
     }
 
     if (window.GM_registerMenuCommand) {
-      const menuId = window.GM_registerMenuCommand(title, fn, accessKey)
-
-      this.menuIds[menuId] = {
+      const menuInfo = {
+        id: null,
         title,
-        fn,
-        accessKey
+        accessKey: menu.accessKey,
+        menu
       }
+      const menuFn = (...args) => {
+        try {
+          menuInfo.menu.fn.apply(menuInfo.menu, args)
+        } catch (e) {
+          console.error('[monkeyMenu]', menuInfo.title, e)
+        }
+      }
+      const menuId = window.GM_registerMenuCommand(title, menuFn, menu.accessKey)
+
+      menuInfo.id = menuId
+      this.menuIds.set(menuKey, menuInfo)
 
       return menuId
     }
   },
 
-  off (id) {
-    if (window.GM_unregisterMenuCommand) {
-      delete this.menuIds[id]
+  off (menuKey) {
+    const menuInfo = this.menuIds.get(menuKey)
+    if (!menuInfo) return true
 
-      /**
-       * 批量移除已注册的按钮时，在某些性能较差的机子上会留下数字title的菜单残留
-       * 应该属于插件自身导致的BUG，暂时无法解决
-       * 所以此处暂时不进行菜单移除，tampermonkey会自动对同名菜单进行合并
-       */
-      // return window.GM_unregisterMenuCommand(id)
+    /* 无法确认命令ID或缺少注销API时保留旧命令，防止重复注册 */
+    if (menuInfo.id === null || menuInfo.id === undefined || !window.GM_unregisterMenuCommand) {
+      return false
     }
+
+    try {
+      window.GM_unregisterMenuCommand(menuInfo.id)
+    } catch (e) {
+      console.error('[monkeyMenu][unregister]', menuInfo.title, e)
+      return false
+    }
+
+    this.menuIds.delete(menuKey)
+    return true
   },
 
   clear () {
-    Object.keys(this.menuIds).forEach(id => {
-      this.off(id)
+    Array.from(this.menuIds.keys()).forEach(menuKey => {
+      this.off(menuKey)
     })
   },
 
   /**
-   * 通过菜单配置进行批量注册，注册前会清空之前注册过的所有菜单
-   * @param {array|function} menuOpts 菜单配置，如果是函数则会调用该函数获取菜单配置，并且当菜单被点击后会重新创建菜单，实现菜单的动态更新
+   * 通过菜单配置同步注册结果，仅新增、移除或更新发生变化的命令
+   * @param {array|function} menuOpts 菜单配置，如果是函数则会调用该函数获取菜单配置
    */
   build (menuOpts) {
-    this.clear()
-
-    if (Array.isArray(menuOpts)) {
-      menuOpts.forEach(menu => {
-        if (menu.disable === true) { return }
-        this.on(menu.title, menu.fn, menu.accessKey)
-      })
-    } else if (menuOpts instanceof Function) {
-      const menuList = menuOpts()
-      if (Array.isArray(menuList)) {
-        this._menuBuilder_ = menuOpts
-
-        menuList.forEach(menu => {
-          if (menu.disable === true) { return }
-
-          const menuFn = () => {
-            try {
-              menu.fn.apply(menu, arguments)
-            } catch (e) {
-              console.error('[monkeyMenu]', menu.title, e)
-            }
-
-            // 每次菜单点击后，重新注册菜单，这样可以确保菜单的状态是最新的
-            setTimeout(() => {
-              // console.log('[monkeyMenu rebuild]', menu.title)
-              this.build(this._menuBuilder_)
-            }, 100)
-          }
-
-          this.on(menu.title, menuFn, menu.accessKey)
-        })
-      } else {
-        console.error('monkeyMenu build error, no menuList return', menuOpts)
-      }
+    const menuList = menuOpts instanceof Function ? menuOpts() : menuOpts
+    if (!Array.isArray(menuList)) {
+      console.error('monkeyMenu build error, no menuList return', menuOpts)
+      return
     }
+
+    const activeMenuKeys = new Set()
+    menuList.forEach(menu => {
+      if (menu.disable === true || !(menu.fn instanceof Function)) return
+
+      /* 显式key可处理重复创建的函数，默认使用稳定的fn引用作为菜单标识 */
+      const menuKey = menu.key || menu.fn
+      activeMenuKeys.add(menuKey)
+      this.on(menu, menuKey)
+    })
+
+    Array.from(this.menuIds.keys()).forEach(menuKey => {
+      if (!activeMenuKeys.has(menuKey)) {
+        this.off(menuKey)
+      }
+    })
   }
 }
 


### PR DESCRIPTION
## 问题

`monkeyMenu.build()` 每次执行都会清空本地记录并重新注册全部菜单，但旧代码实际上没有调用 `GM_unregisterMenuCommand`。同时，每次点击菜单后又会触发一次完整重建，因此旧回调会持续累积；页面中的 iframe 还会重复注册“全局”菜单，进一步放大重复打开配置编辑器的问题。

## 修复

- 使用稳定 key 同步菜单命令，未变化的命令复用原回调，仅在标题、快捷键或可用状态变化时注销/更新。
- 当 userscript manager 无法注销命令时，保留原命令并更新其实际回调，避免再次注册造成叠加。
- 取消“每次点击后完整重建菜单”，只在无需刷新页面的自动播放开关变化后显式同步菜单。
- 全局菜单仅由顶层页面注册；iframe 只保留带域名前缀的局部控制菜单。
- 保留 `openInTab` 的同 URL 限流，作为快速重复点击和第三方脚本重复触发时的防御措施。

## 验证

- ESLint：4 个修改过的源码文件
- Node 回归检查：连续同步 10 次仍只有 1 个注册回调；标题变化、删除菜单、注销抛错和无命令 ID 场景均通过
- `npm run build`
- `node --check dist/h5player.user.js`
- `git diff --check`

Fixes #701
Fixes #737
